### PR TITLE
Hotfix/early fail batch

### DIFF
--- a/hive-interface.js
+++ b/hive-interface.js
@@ -308,6 +308,11 @@ class Hive {
 				}
 				const blocks = await Promise.all(promises);
 				for (const block of blocks) {
+					if (!block || !block.transactions) {
+						utils.log('Error loading block batch that contains [' + block_num + ']', 4);
+						await utils.timeout(1000);
+						return;
+					}
 					await this.processBlockHelper(block, this.last_block + 1, cur_block_num);
 					if(this._options.on_virtual_op) {
 						await this.getVirtualOps(result.last_irreversible_block_num);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@splinterlands/hive-interface",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splinterlands/hive-interface",
-  "version": "2.2.9",
+  "version": "2.3.0",
   "description": "An interface to the Hive blockchain which supports multi-node redundancy for high availability systems.",
   "main": "hive-interface.js",
   "scripts": {


### PR DESCRIPTION
There was a situation in which code I previously introduced would lead to linking transactions to the wrong block; prevent this by not continuing to process a batch of fetched blocks if we know an earlier block was not fetched properly. Version number was also incremented to a new minor release.