### PR TITLE
Bump ssc version to fix axios vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "license": "MIT",
   "dependencies": {
     "@hiveio/dhive": "^1.0.1",
-    "sscjs": "0.0.8"
+    "sscjs": "0.0.9"
   }
 }


### PR DESCRIPTION
The version of axios that sscjs 0.0.8 uses has some big vulnerabilities, they bumped their axios version in 0.0.9 and so updating the ssc version should fix this