### PR TITLE
Handle Multiple Accounts

### DIFF
--- a/hive-interface.js
+++ b/hive-interface.js
@@ -421,7 +421,7 @@ class Hive {
 	checkAccountUsageLimit(account) {
 		if(this.accounts_used.has(account)) {
 			let count = this.accounts_used.get(account);
-			if(count => 4) 
+			if(4 <= count) 
 				return true;
 			else
 				this.accounts_used.set(account, count++);

--- a/hive-interface.js
+++ b/hive-interface.js
@@ -418,6 +418,8 @@ class Hive {
 		});
 	}
 
+	// Check if you have already broadcast 4 transactions from an account, in which case return true.
+	// Otherwise, increment the count and return false.
 	checkAccountUsageLimit(account) {
 		if(this.accounts_used.has(account)) {
 			let count = this.accounts_used.get(account);


### PR DESCRIPTION
Try to add tracking of how many broadcasts we have done per account, per block.  If we hit the limit, leave them in the queue.